### PR TITLE
Breedx2/response bytes

### DIFF
--- a/src/main/java/com/flightstats/http/Response.java
+++ b/src/main/java/com/flightstats/http/Response.java
@@ -23,10 +23,16 @@ public class Response {
         return headers.get(location);
     }
 
+    /**
+     * @return The response body as a String by using the platform's default character set.
+     */
     public String getBodyString() {
         return getBodyString(Charset.defaultCharset());
     }
 
+    /**
+     * @return The response body as a String by using the specified character encoding.
+     */
     public String getBodyString(Charset charset) {
         return new String(body, charset);
     }

--- a/src/main/java/com/flightstats/http/Response.java
+++ b/src/main/java/com/flightstats/http/Response.java
@@ -5,12 +5,13 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import lombok.Value;
 
+import java.nio.charset.Charset;
 import java.util.Collection;
 
 @Value
 public class Response {
     int code;
-    String body;
+    byte[] body;
     Multimap<String, String> headers;
 
     public String getHeader(String location) {
@@ -20,5 +21,13 @@ public class Response {
 
     public Collection<String> getHeaders(String location) {
         return headers.get(location);
+    }
+
+    public String getBodyString() {
+        return getBodyString(Charset.defaultCharset());
+    }
+
+    public String getBodyString(Charset charset) {
+        return new String(body, charset);
     }
 }

--- a/src/test/java/com/flightstats/http/HttpTemplateTest.java
+++ b/src/test/java/com/flightstats/http/HttpTemplateTest.java
@@ -187,14 +187,14 @@ public class HttpTemplateTest {
         Response result = testClass.delete(URI.create("http://lmgtfy.com"));
 
         //THEN
-        assertEquals(new Response(200, body, expectedHeaders), result);
+        assertEquals(new Response(200, body.getBytes(), expectedHeaders), result);
     }
 
     @Test
     public void testGetWithExtraHeaders() throws Exception {
         //GIVEN
         String body = "result body text";
-        Response expected = new Response(200, body, LinkedListMultimap.create());
+        Response expected = new Response(200, body.getBytes(), LinkedListMultimap.create());
 
         HttpResponse response = mock(HttpResponse.class, RETURNS_DEEP_STUBS);
         HttpClient httpClient = mock(HttpClient.class);


### PR DESCRIPTION
Let the Response object use bytes[] and don't assume String. Provide convenience methods to get the bytes as a String. This breaks backwards compatibility with callers that expect getBody() to return String. Callers will need to call getBodyString() instead.