### PR TITLE
simple covering method that doesn't require the response consumer

### DIFF
--- a/src/main/java/com/flightstats/http/HttpTemplate.java
+++ b/src/main/java/com/flightstats/http/HttpTemplate.java
@@ -102,6 +102,10 @@ public class HttpTemplate {
         return handleRequest(request, responseConsumer);
     }
 
+    public Response get(URI uri, Map<String, String> extraHeaders) {
+        return get(uri, res -> {}, extraHeaders);
+    }
+
     private void addExtraHeaders(HttpRequestBase request, Map<String, String> extraHeaders) {
         extraHeaders.entrySet().stream().forEach(entry -> request.setHeader(entry.getKey(), entry.getValue()));
     }


### PR DESCRIPTION
I'm not sure why we need both the consumer and the response returned, but this method would simplify the usages that just want the result, without requiring an empty consumer.