### PR TITLE
Add methods to supply content type when saving things to S3.

### DIFF
--- a/src/main/java/com/flightstats/filesystem/FileSystem.java
+++ b/src/main/java/com/flightstats/filesystem/FileSystem.java
@@ -8,6 +8,8 @@ import java.util.List;
 public interface FileSystem {
     OutputStream outputStream(Path fileName);
 
+    OutputStream outputStream(Path fileName, String contentType);
+
     InputStream inputStream(Path fileName);
 
     String readContents(Path fileName);
@@ -15,6 +17,8 @@ public interface FileSystem {
     boolean exists(Path fileName);
 
     void saveContent(String content, Path fileName);
+
+    void saveContent(String content, Path fileName, String contentType);
 
     /**
      * This will return a list of all paths that are prefixed with the provided Path, even if that Path doesn't point at

--- a/src/main/java/com/flightstats/filesystem/LocalFileSystem.java
+++ b/src/main/java/com/flightstats/filesystem/LocalFileSystem.java
@@ -26,6 +26,11 @@ public class LocalFileSystem implements FileSystem {
     }
 
     @Override
+    public OutputStream outputStream(Path fileName, String contentType) {
+        return outputStream(fileName);
+    }
+
+    @Override
     @SneakyThrows
     public InputStream inputStream(Path fileName) {
         return new FileInputStream(fileName.toFile());
@@ -47,6 +52,11 @@ public class LocalFileSystem implements FileSystem {
     public void saveContent(String content, Path fileName) {
         fileName.toFile().getParentFile().mkdirs();
         Files.write(fileName, content.getBytes(Charsets.UTF_8));
+    }
+
+    @Override
+    public void saveContent(String content, Path fileName, String contentType) {
+        saveContent(content, fileName);
     }
 
     @Override


### PR DESCRIPTION
This is super useful, when you want to expose your S3 stuff as publicly accessible and web addressable. 