### PR TITLE
rename argument to better reflect its purpose.

### DIFF
--- a/src/main/java/com/flightstats/http/Response.java
+++ b/src/main/java/com/flightstats/http/Response.java
@@ -16,13 +16,13 @@ public class Response {
     byte[] body;
     Multimap<String, String> headers;
 
-    public String getHeader(String location) {
-        Collection<String> headers = this.headers.get(location);
+    public String getHeader(String headerName) {
+        Collection<String> headers = this.headers.get(headerName);
         return headers == null ? null : Iterables.getFirst(headers, null);
     }
 
-    public Collection<String> getHeaders(String location) {
-        return headers.get(location);
+    public Collection<String> getHeaders(String headerName) {
+        return headers.get(headerName);
     }
 
     /**


### PR DESCRIPTION
Simple change here to rename the argument from `location` to `headerName`. 
